### PR TITLE
added configurable recursion limit to original genome depth calculation

### DIFF
--- a/src/Genome.cpp
+++ b/src/Genome.cpp
@@ -66,6 +66,7 @@ namespace NEAT
         m_ID = 0;
         m_Fitness = -std::numeric_limits<double>::infinity();
         m_Depth = 0;
+        m_NeuronRecursionLimit = 16384;
         m_LinkGenes.clear();
         m_NeuronGenes.clear();
         m_NumInputs = 0;
@@ -84,6 +85,7 @@ namespace NEAT
     {
         m_ID = a_G.m_ID;
         m_Depth = a_G.m_Depth;
+        m_NeuronRecursionLimit = a_G.m_NeuronRecursionLimit;
         m_NeuronGenes = a_G.m_NeuronGenes;
         m_LinkGenes = a_G.m_LinkGenes;
         m_GenomeGene = a_G.m_GenomeGene;
@@ -109,6 +111,7 @@ namespace NEAT
         {
             m_ID = a_G.m_ID;
             m_Depth = a_G.m_Depth;
+            m_NeuronRecursionLimit = a_G.m_NeuronRecursionLimit;
             m_NeuronGenes = a_G.m_NeuronGenes;
             m_LinkGenes = a_G.m_LinkGenes;
             m_GenomeGene = a_G.m_GenomeGene;
@@ -239,6 +242,7 @@ namespace NEAT
         m_AdjustedFitness = 0.0;
         m_OffspringAmount = 0.0;
         m_Depth = 0;
+        m_NeuronRecursionLimit = a_Parameters.NeuronRecursionLimit;
         m_PhenotypeBehavior = NULL;
         
         m_initial_num_neurons = NumNeurons();
@@ -489,6 +493,7 @@ namespace NEAT
         m_AdjustedFitness = 0.0;
         m_OffspringAmount = 0.0;
         m_Depth = 0;
+        m_NeuronRecursionLimit = a_Parameters.NeuronRecursionLimit;
         m_PhenotypeBehavior = NULL;
     
         m_initial_num_neurons = NumNeurons();
@@ -503,6 +508,16 @@ namespace NEAT
     unsigned int Genome::GetDepth() const
     {
         return m_Depth;
+    }
+
+    void Genome::SetNeuronRecursionLimit(unsigned int a_l)
+    {
+        m_NeuronRecursionLimit = a_l;
+    }
+
+    unsigned int Genome::GetNeuronRecursionLimit() const
+    {
+        return m_NeuronRecursionLimit;
     }
 
     void Genome::SetID(unsigned int a_id)
@@ -3190,11 +3205,11 @@ namespace NEAT
         unsigned int t_current_depth;
         unsigned int t_max_depth = a_Depth;
 
-        if (a_Depth > 16384)
+        if (a_Depth > m_NeuronRecursionLimit)
         {
             // oops! a possible loop in the network!
             // DBG(" ERROR! Trying to get the depth of a looped network!");
-            return 16384;
+            return m_NeuronRecursionLimit;
         }
 
         // Base case

--- a/src/Genome.h
+++ b/src/Genome.h
@@ -103,6 +103,9 @@ namespace NEAT
         // The depth of the network
         unsigned int m_Depth;
 
+        // recursion limit on network depth calculations
+        unsigned int m_NeuronRecursionLimit;
+
         // how many individuals this genome should spawn
         double m_OffspringAmount;
 
@@ -265,6 +268,10 @@ namespace NEAT
         unsigned int GetDepth() const;
 
         void SetDepth(unsigned int a_d);
+
+        unsigned int GetNeuronRecursionLimit() const;
+
+        void SetNeuronRecursionLimit(unsigned int a_l);
 
         // Returns true if there is any dead end in the network
         bool HasDeadEnds() const;

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -150,7 +150,8 @@ namespace NEAT
         // Fraction of individuals to be copied unchanged
         EliteFraction = 0.01;
 
-
+        // Recursion limit for network depth calculations
+        NeuronRecursionLimit = 16384;
 
 
 

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -508,6 +508,7 @@ namespace NEAT
         , RouletteWheelSelection(false)
         , TournamentSize(4)
         , EliteFraction(0.01)
+        , NeuronRecursionLimit(16384)
         // Phased Search parameters
         , PhasedSearching(false)
         , DeltaCoding(false)
@@ -1073,6 +1074,10 @@ namespace NEAT
             if (s == "Elitism")
             {
                 a_DataFile >> EliteFraction;
+            }
+            if (s == "NeuronRecursionLimit")
+            {
+                a_DataFile >> NeuronRecursionLimit;
             }
         }
 

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -173,6 +173,8 @@ public:
     // Fraction of individuals to be copied unchanged
     double EliteFraction;
 
+    // Recursion limit for network depth calculations
+    unsigned int NeuronRecursionLimit;
 
 
     ///////////////////////////////////

--- a/src/Population.cpp
+++ b/src/Population.cpp
@@ -114,6 +114,7 @@ Population::Population(const Genome& a_Seed, const Parameters& a_Parameters,
             }
         }
 
+        m_Genomes[i].SetNeuronRecursionLimit(a_Parameters.NeuronRecursionLimit);
         //m_Genomes[i].CalculateDepth();
     }
     // Speciate

--- a/src/PythonBindings.cpp
+++ b/src/PythonBindings.cpp
@@ -579,7 +579,7 @@ BOOST_PYTHON_MODULE(_multineat)
             .def_readwrite("GeometrySeed", &Parameters::GeometrySeed)
             .def_readwrite("TournamentSize", &Parameters::TournamentSize)
             .def_readwrite("EliteFraction", &Parameters::EliteFraction)
-
+            .def_readwrite("NeuronRecursionLimit", &Parameters::NeuronRecursionLimit)
 			.def_pickle(Parameters_pickle_suite())
         ;
 

--- a/src/Species.cpp
+++ b/src/Species.cpp
@@ -498,6 +498,7 @@ namespace NEAT
             // We have a new offspring now
             // give the offspring a new ID
             t_baby.SetID(a_Pop.GetNextGenomeID());
+            t_baby.SetNeuronRecursionLimit(a_Parameters.NeuronRecursionLimit);
             a_Pop.IncrementNextGenomeID();
 
             // sort the baby's genes


### PR DESCRIPTION
The function `NeuronDepth` either causes a stack overflow exception or took forever to return on my machine. This problem was noted by someone else in the original repo. (Not sure if I'm missing something elsewhere but the same problem occurs in `NeuralNetwork` > `NodeDepth`) Setting this limit <16384 solved this problem for me--but it is dirty. This is an attempt to make it configurable.